### PR TITLE
Added a Clojure and repl-friendly dev workflow shadow-cljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ See the `shadow-cljs` _user-guide_ on how to install it.
 
 See the `Leiningen` Installation docs to install it.
 
-# Running the project
+# Development workflow using the shadow-cljs CLI
 
 ## Running a watch process
 
-To start a `watch` process which will monitor changes and automatically recompile the `dashboard` code base, run :
+To start a `watch` process which will monitor changes and automatically recompile the `dashboard` code base, run the following from your terminal:
 
 `$ shadow-cljs watch :dashboard`
 
 a `watch` will implicitly start a _server process_ which will be re-used by all commands sent by the CLI, instead of starting a new JVM.
 
-```
+```shell script
  + react-dom@16.13.0
  + react@16.13.0
  added 1 package, updated 2 packages and audited 36 packages in 4.611s
@@ -38,6 +38,17 @@ a `watch` will implicitly start a _server process_ which will be re-used by all 
  [:dashboard] Configuring build.
  [:dashboard] Compiling ...
  [:dashboard] Build completed. (157 files, 156 compiled, 0 warnings, 35.04s)
+```
+
+To stop the `watch` process, just type in CTRL-C from the CLI : 
+
+```shell script
+ ...
+ [:dashboard] Configuring build.
+ [:dashboard] Compiling ...
+ [:dashboard] Build completed. (157 files, 156 compiled, 0 warnings, 35.04s)
+
+ Ctrl^C
 ```
 
 ## The REPL
@@ -58,4 +69,91 @@ found 0 vulnerabilities
 [:browser-repl] Compiling ...
 [:browser-repl] Build completed. (157 files, 156 compiled, 0 warnings, 21.91s)
 cljs.user=>
+```
+
+# Development workflow using the provided `dev.clj` namespace
+
+We also provide a `dev.clj` namespace in `dev/dev.clj` which allows for a more Clojure-_friendly_ workflow during development.
+This namespace contains a few utility functions for _programmatically_ interacting with `shadow-cljs` through its Clojure API.
+The first step is to `eval` those functions in your REPL.
+
+```clojure
+...
+(defn- compile-build
+  "Compiles a build `build-id` where `build-id` is a
+  keyword identifying a build.
+  This is equivalent to invoking :
+  $ shadow-cljs compile :build-id"
+  [build-id]
+  (shadow/compile build-id))
+=> nil
+=> #'dev/start-server
+=> #'dev/stop-server
+=> #'dev/re-init-server
+=> #'dev/watch-build
+=> #'dev/compile-build
+
+```
+
+You can then `watch` or `compile` a build, `start`, `stop` or `re-init` the `shadow-cljs` server by just calling those functions from within the REPL.
+
+## Starting the shadow-cljs server
+
+```clojure
+;; starts a shadow-cljs server
+(start-server)
+avr. 13, 2020 1:08:25 PM org.xnio.Xnio <clinit>
+INFO: XNIO version 3.7.3.Final
+avr. 13, 2020 1:08:25 PM org.xnio.nio.NioXnio <clinit>
+INFO: XNIO NIO Implementation Version 3.7.3.Final
+avr. 13, 2020 1:08:25 PM org.jboss.threads.Version <clinit>
+INFO: JBoss Threads version 2.3.2.Final
+shadow-cljs - server version: 2.8.94 running at http://localhost:9630
+shadow-cljs - nREPL server started on port 34619
+=> :shadow.cljs.devtools.server/started
+
+;; since a shadow-cljs server is already running
+(start-server)
+=> :shadow.cljs.devtools.server/already-running
+```
+
+## Shutting down the shadow-cljs server
+
+```clojure
+;; stops the running shadow-cljs server
+(stop-server)
+shutting down ...
+=> nil
+```
+
+## Re-initializing the shadow-cljs server
+
+```clojure
+;; re-initializes the running shadow-cljs server
+(re-init-server)
+shadow-cljs - server version: 2.8.94 running at http://localhost:9630
+shadow-cljs - nREPL server started on port 42915
+=> :shadow.cljs.devtools.server/started
+```
+
+## Watching a build
+
+```clojure
+;; watches a build (e.g here :dashboard)
+(watch-build :dashboard)
+[:dashboard] Configuring build.
+[:dashboard] Compiling ...
+=> :watching
+[:dashboard] Build completed. (157 files, 1 compiled, 0 warnings, 2,18s)
+...
+```
+
+## Compiling a build
+
+```clojure
+;; compiles a build (e.g here :dashboard)
+(compile-build :dashboard)
+[:dashboard] Compiling ...
+[:dashboard] Build completed. (59 files, 0 compiled, 0 warnings, 0,58s)
+=> :done
 ```

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -1,0 +1,60 @@
+(ns dev
+  (:require [shadow.cljs.devtools.server :as server]
+            [shadow.cljs.devtools.api :as shadow]))
+
+(defn- start-server
+  "Starts a shadow-cljs server process which will be used
+  by all subsequent processes.
+  This is equivalent to invoking :
+  $ shadow-cljs start server"
+  []
+  (server/start!))
+
+(defn- stop-server
+  "Stops the running shadow-cljs server process.
+  This is equivalent to invoking :
+  $ shadow-cljs stop server"
+  []
+  (server/stop!))
+
+(defn- re-init-server
+  "Re-initializes the running shadow-cljs server"
+  []
+  (do
+    (server/stop!)
+    (server/start!)))
+
+(defn- watch-build
+  "Starts a watch on build `build-id` where `build-id` is
+  a keyword identifying a build. Optionally starts a shadow-cljs
+  server process if none is running.
+  This is equivalent to invoking :
+  $ shadow-cljs watch :build-id"
+  [build-id]
+  (shadow/watch build-id))
+
+(defn- compile-build
+  "Compiles a build `build-id` where `build-id` is a
+  keyword identifying a build.
+  This is equivalent to invoking :
+  $ shadow-cljs compile :build-id"
+  [build-id]
+  (shadow/compile build-id))
+
+(do
+
+  ;; You can just `eval` the following functions to control any
+  ;; aspect of your build.
+
+  ;; starts a shadow-cljs server
+  (start-server)
+  ;; stops the running shadow-cljs server
+  (stop-server)
+  ;; re-initializes the running shadow-cljs server
+  (re-init-server)
+  
+  ;; watches a build (e.g here :dashboard)
+  (watch-build :dashboard)
+  ;; compiles a build (e.g here :dashboard)
+  (compile-build :dashboard)
+  )


### PR DESCRIPTION
I have added a `dev.clj ` namespace to allow for a more _Clojure_ and _REPL_-friendly interaction with the `shadow-cljs` build process instead of having to use the `shell CLI`. 

I have also updated the `README` accordingly.

Can you PTAL @devth 

thanks in advance ;-)